### PR TITLE
Bump pinned Tessl skill-review-and-optimize SHA to the current release (pre-migration commit no longer works)

### DIFF
--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -20,6 +20,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+      - uses: tesslio/skill-review-and-optimize@90e919d50ecb2dd11e07d69ef1440e7b2716189b
         with:
           mode: apply

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+      - uses: tesslio/skill-review-and-optimize@90e919d50ecb2dd11e07d69ef1440e7b2716189b
         with:
           optimize: true
           tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
Hi 👋 I'm Alan from Tessl — thanks for running our `skill-review-and-optimize` action in full-stack-skills!

Your workflow(s) (`skill-optimize-apply.yml` + `skill-review.yml`) pin a commit that predates our migration to Tessl Review (30–31 Jul), so reviews no longer run correctly on it. This PR bumps the pin to the current release commit (`90e919d`), keeping it a pinned SHA to match how you pin the action. Your workflow already passes `TESSL_API_TOKEN`, so nothing else needs to change.

(The action isn't tagged yet, so a commit SHA is the right thing to pin.)

Thanks for building with Tessl! 🙏 — Alan